### PR TITLE
Update ToastView.m to disable toast interaction

### DIFF
--- a/Plugins/iOS/ToastView.m
+++ b/Plugins/iOS/ToastView.m
@@ -70,7 +70,8 @@ float const ToastGap = 10.0f;
     toast.alpha = 0.0f;
     toast.layer.cornerRadius = 4.0;
     toast.text = text;
-
+    toast.userInteractionEnabled = NO;
+    
     [parentView addSubview:toast];
 
     [UIView animateWithDuration:0.4 animations:^{


### PR DESCRIPTION
There were some instances where we encountered that the toast message in IOS was clickable which led to some weird behavior. This change worked perfectly for us. As we set the toast to be non interactable.